### PR TITLE
Fix missing import for preprocessing

### DIFF
--- a/preprocess_data.py
+++ b/preprocess_data.py
@@ -10,6 +10,7 @@ import io
 from tqdm import tqdm
 import numpy as np
 import chess.pgn
+from utils import board_to_vector
 
 
 def include_game(pgn_str: str, min_elo: int = 1500) -> bool:


### PR DESCRIPTION
## Summary
- import shared board_to_vector util in preprocessing

## Testing
- `python -m py_compile preprocess_data.py`


------
https://chatgpt.com/codex/tasks/task_e_683f86732f488323b082ee074a057d95